### PR TITLE
Feature/improve component url handling

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -192,7 +192,7 @@ pipeline {
     stages {
         stage('Create manifest') {
             steps {
-                componentManifest inputPath: 'input.json', outputPath: 'output.pdf', templateUrl: 'file://template.ftl'
+                componentManifest inputPath: 'input.json', outputPath: 'output.pdf', templateUrl: 'file://template.ftl', ignoreUnavailableUrl: true
             }
         }
     }
@@ -201,6 +201,8 @@ pipeline {
 
 With the parameter `templateUrl`, you can specify a URL pointing to a custom FreeMarker template which is used to create the output. The parameter is optional.
 If it is not set, the template from link:core/src/main/resources/de/medavis/lct/core/outputter/DefaultComponentManifest.ftlh[de.medavis.lct.core.outputter.DefaultComponentManifest.ftlh] is used.
+
+If the parameter `ignoreUnavailableUrl` is set (default value: `false`), URLs from the SBOM are ignored when they are not available, i.e. no connection can be established or they return a different status code than 200. This is useful to prevent the generated component manifest from containing invalid links.
 
 
 === Download licenses

--- a/cli/src/main/java/de/medavis/lct/cli/AnalyzeComponents.java
+++ b/cli/src/main/java/de/medavis/lct/cli/AnalyzeComponents.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * License Compliance Tool - Command Line Interface
+ * %%
+ * Copyright (C) 2022 - 2023 medavis GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.medavis.lct.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import de.medavis.lct.core.asset.AssetLoader;
+import de.medavis.lct.core.license.LicenseLoader;
+import de.medavis.lct.core.license.LicenseMappingLoader;
+import de.medavis.lct.core.list.ComponentLister;
+import de.medavis.lct.core.metadata.ComponentMetaDataLoader;
+
+import static de.medavis.lct.cli.AnalyzeComponents.AnalyzeMode.MISSING_URL;
+
+@Command(name = "analyze-components", description = "Analyze components based on specified criteria")
+class AnalyzeComponents implements Callable<Void> {
+
+    enum AnalyzeMode {
+        MISSING_URL
+    }
+
+    @Option(names = {"--in", "-i"}, required = true)
+    private File inputFile;
+    @Option(names = {"--out", "-o"}, required = true)
+    private File outputFile;
+    @Option(names = {"--mode", "-m"}, required = true)
+    private AnalyzeMode mode;
+
+    @Mixin
+    private ConfigurationOptions configurationOptions;
+
+    @Override
+    public Void call() throws Exception {
+        if(mode == MISSING_URL) {
+            analyzeMissingUrl();
+        }
+        return null;
+    }
+
+    private void analyzeMissingUrl() throws IOException {
+        var componentLister = new ComponentLister(new AssetLoader(true), new ComponentMetaDataLoader(), new LicenseLoader(), new LicenseMappingLoader(),
+                configurationOptions);
+        try(var bomInputStream = new FileInputStream(inputFile)) {
+            var componentsWithoutUrl = componentLister.listComponents(bomInputStream).stream()
+                                                      .filter(component -> component.getUrl() == null)
+                                                      .collect(Collectors.toList());
+            if(componentsWithoutUrl.isEmpty()) {
+                System.out.println("No component without URL detected.");
+            } else {
+                System.out.printf("Detected %d components without URL:%n", componentsWithoutUrl.size());
+                componentsWithoutUrl.forEach(component -> System.out.println(component.getName()));
+            }
+        }
+    }
+
+}

--- a/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
+++ b/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
@@ -44,12 +44,14 @@ class CreateManifest implements Callable<Void> {
     private File outputFile;
     @Option(names = {"--template", "-t"})
     private String template;
+    @Option(names = {"--ignoreUnavailableUrl", "-iuu"}, defaultValue = "true")
+    private boolean ignoreUnavailableUrl;
     @Mixin
     private ConfigurationOptions configurationOptions;
 
     @Override
     public Void call() throws Exception {
-        var componentLister = new ComponentLister(new AssetLoader(true), new ComponentMetaDataLoader(), new LicenseLoader(), new LicenseMappingLoader(),
+        var componentLister = new ComponentLister(new AssetLoader(ignoreUnavailableUrl), new ComponentMetaDataLoader(), new LicenseLoader(), new LicenseMappingLoader(),
                 configurationOptions);
         try (var bomInputStream = new FileInputStream(inputFile); var outputWriter = new FileWriter(outputFile)) {
             var components = componentLister.listComponents(bomInputStream);

--- a/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
+++ b/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
@@ -44,7 +44,7 @@ class CreateManifest implements Callable<Void> {
     private File outputFile;
     @Option(names = {"--template", "-t"})
     private String template;
-    @Option(names = {"--ignoreUnavailableUrl", "-iuu"}, defaultValue = "true")
+    @Option(names = {"--ignoreUnavailableUrl", "-iuu"}, defaultValue = "false")
     private boolean ignoreUnavailableUrl;
     @Mixin
     private ConfigurationOptions configurationOptions;

--- a/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
+++ b/cli/src/main/java/de/medavis/lct/cli/CreateManifest.java
@@ -49,7 +49,7 @@ class CreateManifest implements Callable<Void> {
 
     @Override
     public Void call() throws Exception {
-        var componentLister = new ComponentLister(new AssetLoader(), new ComponentMetaDataLoader(), new LicenseLoader(), new LicenseMappingLoader(),
+        var componentLister = new ComponentLister(new AssetLoader(true), new ComponentMetaDataLoader(), new LicenseLoader(), new LicenseMappingLoader(),
                 configurationOptions);
         try (var bomInputStream = new FileInputStream(inputFile); var outputWriter = new FileWriter(outputFile)) {
             var components = componentLister.listComponents(bomInputStream);

--- a/cli/src/main/java/de/medavis/lct/cli/Main.java
+++ b/cli/src/main/java/de/medavis/lct/cli/Main.java
@@ -33,6 +33,7 @@ class Main {
         commandLine.addSubcommand(new HelpCommand());
         commandLine.addSubcommand(new CreateManifest());
         commandLine.addSubcommand(new DownloadLicenses());
+        commandLine.addSubcommand(new AnalyzeComponents());
         System.exit(commandLine.execute(args));
     }
 

--- a/core/src/main/java/de/medavis/lct/core/urlchecker/HttpUrlChecker.java
+++ b/core/src/main/java/de/medavis/lct/core/urlchecker/HttpUrlChecker.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * License Compliance Tool - Implementation Core
+ * %%
+ * Copyright (C) 2022 - 2024 medavis GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.medavis.lct.core.urlchecker;
+
+public interface HttpUrlChecker {
+
+    /**
+     * Check if <code>urlString</code> is a valid HTTP(S) url and can be accessed. The check is successful only if the result has status code 200.
+     *
+     * @param urlString
+     * @return
+     */
+    boolean isUrlAvailable(String urlString);
+}

--- a/core/src/main/java/de/medavis/lct/core/urlchecker/OnlineHttpUrlChecker.java
+++ b/core/src/main/java/de/medavis/lct/core/urlchecker/OnlineHttpUrlChecker.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * License Compliance Tool - Implementation Core
+ * %%
+ * Copyright (C) 2022 - 2024 medavis GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.medavis.lct.core.urlchecker;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+/**
+ * Implementation of {@link HttpUrlChecker} that accesses the URL over the Internet.
+ */
+public class OnlineHttpUrlChecker implements HttpUrlChecker {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final HttpClient httpClient = java.net.http.HttpClient.newBuilder()
+                                                                  .followRedirects(HttpClient.Redirect.NORMAL)
+                                                                  .connectTimeout(Duration.of(1, SECONDS))
+                                                                  .build();
+
+    @Override
+    public boolean isUrlAvailable(String urlString) {
+        boolean result = false;
+        String reason;
+        try {
+            var req = HttpRequest.newBuilder()
+                                 .uri(new URI(urlString))
+                                 .GET()
+                                 .build();
+            var resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
+            result = resp.statusCode() == 200;
+            reason = "Status code is " + resp.statusCode();
+        } catch(Exception e) {
+            if(e instanceof InterruptedException) {
+                // Thread was interrupted, re-interrupt it
+                Thread.currentThread().interrupt();
+            }
+            result = false;
+            reason = "Exception: " + e.getMessage();
+        }
+        if (!result) {
+            log.debug("URL {} is not available. Reason: {}", urlString, reason);
+        }
+        return result;
+
+    }
+
+}

--- a/core/src/test/java/de/medavis/lct/core/asset/AssetLoaderOnlineAvailabilityCheckTest.java
+++ b/core/src/test/java/de/medavis/lct/core/asset/AssetLoaderOnlineAvailabilityCheckTest.java
@@ -1,0 +1,102 @@
+/*-
+ * #%L
+ * License Compliance Tool
+ * %%
+ * Copyright (C) 2022 medavis GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.medavis.lct.core.asset;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.common.io.Resources;
+import org.apache.commons.io.IOUtils;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeAllMappings;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+class AssetLoaderOnlineAvailabilityCheckTest {
+
+    private final static String SAMPLE_BOM_TEMPLATE = "asset/test-bom-urlcheck.tmpl.json";
+    private static final String URL_PATH_VCS = "/vcs";
+    private static final String URL_PATH_WEBSITE = "/website";
+
+    private final AssetLoader underTest = new AssetLoader(true);
+    private InputStream bomWithWireMockUrl;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        var bomWithWireMockUrlString = Resources.asCharSource(Resources.getResource(SAMPLE_BOM_TEMPLATE), StandardCharsets.UTF_8)
+                                                .lines()
+                                                .collect(Collectors.joining("\n"))
+                                                .replaceAll("\\Q{{mockUrl}}\\E", wmRuntimeInfo.getHttpBaseUrl());
+
+        bomWithWireMockUrl = IOUtils.toInputStream(bomWithWireMockUrlString, StandardCharsets.UTF_8);
+    }
+
+    @AfterEach
+    void tearDown() {
+        removeAllMappings();
+    }
+
+    @Test
+    void shouldPreferVCSOverWebsite(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(URL_PATH_VCS).willReturn(ok()));
+        stubFor(get(URL_PATH_WEBSITE).willReturn(ok()));
+
+        Asset actual = underTest.loadFromBom(bomWithWireMockUrl);
+
+        assertComponentUrl(actual).isEqualTo(wmRuntimeInfo.getHttpBaseUrl() + URL_PATH_VCS);
+    }
+
+    @Test
+    void shouldUseWebsiteIfVCSIsNotAvailable(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(URL_PATH_VCS).willReturn(notFound()));
+        stubFor(get(URL_PATH_WEBSITE).willReturn(ok()));
+
+        Asset actual = underTest.loadFromBom(bomWithWireMockUrl);
+
+        assertComponentUrl(actual).isEqualTo(wmRuntimeInfo.getHttpBaseUrl() + URL_PATH_WEBSITE);
+    }
+
+    @Test
+    void shouldReturnNullWhenBothVCSAndWebsiteAreNotAvailable(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(URL_PATH_VCS).willReturn(notFound()));
+        stubFor(get(URL_PATH_WEBSITE).willReturn(notFound()));
+
+        Asset actual = underTest.loadFromBom(bomWithWireMockUrl);
+
+        assertComponentUrl(actual).isNull();
+    }
+
+    private static AbstractObjectAssert<?, String> assertComponentUrl(final Asset actual) {
+        return assertThat(actual.components()).hasSize(1).first().extracting(Component::url);
+    }
+
+}

--- a/core/src/test/resources/asset/test-bom-urlcheck.tmpl.json
+++ b/core/src/test/resources/asset/test-bom-urlcheck.tmpl.json
@@ -1,0 +1,132 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:221ec8a8-97b9-468d-9687-043e71d5cccd",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-07-12T11:18:26Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.6.2",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "ff29fc50797fce0b33058a6b2b283f64"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "597e59ebf21c3b8bfb1faeb622569df324eca956"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "3cf9130fcac45a7beb6df2ae9c3fc9c062d1fddd0731d6a302968586f0aa586e"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "8111a6788c959305af23daecbc79defd4478c1e274cba65bfe860e09b30cd9fe29822d5d3d3eea608e4926a9418f92e3"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "2bea87b7bcd70897bf46a28a806b6064a6708d0a45e884e1ceddc25f97ca7bdf4ed190f30d9a28cc9416b6c66176d518c5876fd25bc06bdcb00d39367215e56e"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "de.medavis",
+      "name" : "bommanager",
+      "version" : "1.0-SNAPSHOT",
+      "licenses" : [ ],
+      "purl" : "pkg:maven/de.medavis/bommanager@1.0-SNAPSHOT?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/de.medavis/bommanager@1.0-SNAPSHOT?type=jar"
+    }
+  },
+  "components" : [
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-classic",
+      "version" : "1.2.11",
+      "description" : "logback-classic module",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e13679004cc76ad5792f275f04884fab"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4741689214e9d1e8408b206506cbe76d1c6a7d60"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4d8e899621a3006c2f66e19feab002b11e6cfc5cb1854fc41f01532c00deb2aa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d480881d1a0d58c94aba0b719d56cd492147bc6481b67370dc7426ea7a81326af5b19f32d6a95fee714f37b90a5eed76"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6df8b42396c5d3257f11fb19c280533aa28d66e647115816d4ebfd6a58c9b5adf0e098504772261b29435df75b86cb2b9a47f846ed45d770179c9d10f39941de"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "{{mockUrl}}/website"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "{{mockUrl}}/vcs"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/de.medavis/bommanager@1.0-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/jenkins/src/main/java/de/medavis/lct/jenkins/create/CreateManifestBuilder.java
+++ b/jenkins/src/main/java/de/medavis/lct/jenkins/create/CreateManifestBuilder.java
@@ -67,15 +67,16 @@ public class CreateManifestBuilder extends Builder implements SimpleBuildStep {
     private final String inputPath;
     private final String outputPath;
     private String templateUrl;
+    private boolean ignoreUnavailableUrl;
 
-    private final transient ComponentLister componentLister;
+    private transient ComponentLister componentLister;
     private final transient FreemarkerOutputter outputter;
 
     @DataBoundConstructor
     public CreateManifestBuilder(@NonNull String inputPath, @NonNull String outputPath) {
         this.inputPath = inputPath;
         this.outputPath = outputPath;
-        this.componentLister = CreateManifestBuilderFactory.getComponentLister(ManifestGlobalConfiguration.getInstance());
+        this.componentLister = CreateManifestBuilderFactory.getComponentLister(ManifestGlobalConfiguration.getInstance(), false);
         this.outputter = CreateManifestBuilderFactory.getOutputterFactory();
     }
 
@@ -91,9 +92,21 @@ public class CreateManifestBuilder extends Builder implements SimpleBuildStep {
         return templateUrl;
     }
 
+    public boolean isIgnoreUnavailableUrl() {
+        return ignoreUnavailableUrl;
+    }
+
     @DataBoundSetter
     public void setTemplateUrl(String templateUrl) {
         this.templateUrl = templateUrl;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreUnavailableUrl(final boolean ignoreUnavailableUrl) {
+        if (this.ignoreUnavailableUrl != ignoreUnavailableUrl) {
+            this.componentLister = CreateManifestBuilderFactory.getComponentLister(ManifestGlobalConfiguration.getInstance(), ignoreUnavailableUrl);
+            this.ignoreUnavailableUrl = ignoreUnavailableUrl;
+        }
     }
 
     @Override

--- a/jenkins/src/main/java/de/medavis/lct/jenkins/create/CreateManifestBuilderFactory.java
+++ b/jenkins/src/main/java/de/medavis/lct/jenkins/create/CreateManifestBuilderFactory.java
@@ -19,6 +19,7 @@
  */
 package de.medavis.lct.jenkins.create;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -33,8 +34,8 @@ import de.medavis.lct.core.outputter.FreemarkerOutputter;
 // TODO Try to use dependency injection (maybe using ExtensionFinder, GuiceFinder?)
 class CreateManifestBuilderFactory {
 
-    private static Function<Configuration, ComponentLister> componentListerFactory = configuration -> new ComponentLister(
-            new AssetLoader(),
+    private static BiFunction<Configuration, Boolean, ComponentLister> componentListerFactory = (configuration, ignoreUnavailableUrl) -> new ComponentLister(
+            new AssetLoader(ignoreUnavailableUrl),
             new ComponentMetaDataLoader(),
             new LicenseLoader(),
             new LicenseMappingLoader(),
@@ -44,8 +45,8 @@ class CreateManifestBuilderFactory {
     private CreateManifestBuilderFactory() {
     }
 
-    public static ComponentLister getComponentLister(Configuration configuration) {
-        return componentListerFactory.apply(configuration);
+    public static ComponentLister getComponentLister(Configuration configuration, final boolean ignoreUnavailableUrl) {
+        return componentListerFactory.apply(configuration, ignoreUnavailableUrl);
     }
 
     public static FreemarkerOutputter getOutputterFactory() {
@@ -55,7 +56,7 @@ class CreateManifestBuilderFactory {
     /**
      * Should only be used for tests
      */
-    static void setComponentListerFactory(Function<Configuration, ComponentLister> componentListerFactory) {
+    static void setComponentListerFactory(BiFunction<Configuration, Boolean, ComponentLister> componentListerFactory) {
         CreateManifestBuilderFactory.componentListerFactory = componentListerFactory;
     }
 

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.jelly
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.jelly
@@ -9,4 +9,7 @@
     <f:entry title="${%templateUrl}" field="templateUrl" description="${%templateUrl.description}">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%ignoreUnavailableUrl}" field="ignoreUnavailableUrl" description="${%ignoreUnavailableUrl.description}">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.properties
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.properties
@@ -23,3 +23,5 @@ outputPath=Output path
 outputPath.description=Path to the output file. File will be overwritten if it exists.
 templateUrl=Template (URL)
 templateUrl.description=URL pointing to the template for the output file. Can be file or https.
+ignoreUnavailableUrl=Ignore unavailable URL
+ignoreUnavailableUrl.description=URL of components that are not available will be ignored. Requires Internet access.

--- a/jenkins/src/test/java/de/medavis/lct/jenkins/create/CreateManifestBuilderTest.java
+++ b/jenkins/src/test/java/de/medavis/lct/jenkins/create/CreateManifestBuilderTest.java
@@ -74,7 +74,7 @@ class CreateManifestBuilderTest {
 
     @BeforeEach
     public void setUp() throws IOException {
-        CreateManifestBuilderFactory.setComponentListerFactory(configuration -> componentListerMock);
+        CreateManifestBuilderFactory.setComponentListerFactory((configuration, ignoreUnavailableUrl) -> componentListerMock);
         when(componentListerMock.listComponents(argThat(new InputStreamContentArgumentMatcher(FAKE_SBOM)))).thenReturn(COMPONENT_LIST);
 
         CreateManifestBuilderFactory.setOutputterFactory(() -> outputterMock);


### PR DESCRIPTION
Introduce a new option `ignoreUnavailableUrl` for the creation of a component manifest. If active, URLs from SBOM will be ignored unless they are available with a 200 status. Additionally, The CLI tool has a new command `analyze-components` to list components that, after taken this availability check and URLs from component meta data into account, do not have an URL.