### PR TITLE
Feature/allow override of global configuration

### DIFF
--- a/jenkins/src/main/java/de/medavis/lct/jenkins/config/ManifestGlobalConfiguration.java
+++ b/jenkins/src/main/java/de/medavis/lct/jenkins/config/ManifestGlobalConfiguration.java
@@ -50,10 +50,10 @@ public class ManifestGlobalConfiguration extends GlobalConfiguration implements 
     public static ManifestGlobalConfiguration getInstance(String componentMetadataOverride, String licensesOverride, String licenseMappingsOverride) {
         var defaultConfiguration = GlobalConfiguration.all().getInstance(ManifestGlobalConfiguration.class);
         var result = new ManifestGlobalConfiguration();
-       result.setComponentMetadata(componentMetadataOverride != null ? componentMetadataOverride : defaultConfiguration.getComponentMetadata());
-       result.setLicenses(licensesOverride != null ? licensesOverride : defaultConfiguration.getLicenses());
-       result.setLicenseMappings(licenseMappingsOverride != null ? licenseMappingsOverride : defaultConfiguration.getLicenseMappings());
-       return result;
+        result.setComponentMetadata(!Strings.isNullOrEmpty(componentMetadataOverride) ? componentMetadataOverride : defaultConfiguration.getComponentMetadata());
+        result.setLicenses(!Strings.isNullOrEmpty(licensesOverride) ? licensesOverride : defaultConfiguration.getLicenses());
+        result.setLicenseMappings(!Strings.isNullOrEmpty(licenseMappingsOverride) ? licenseMappingsOverride : defaultConfiguration.getLicenseMappings());
+        return result;
     }
 
     public String getComponentMetadata() {

--- a/jenkins/src/main/java/de/medavis/lct/jenkins/config/ManifestGlobalConfiguration.java
+++ b/jenkins/src/main/java/de/medavis/lct/jenkins/config/ManifestGlobalConfiguration.java
@@ -25,9 +25,6 @@ import hudson.model.PersistentDescriptor;
 import hudson.util.FormValidation;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import jenkins.model.GlobalConfiguration;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -47,7 +44,16 @@ public class ManifestGlobalConfiguration extends GlobalConfiguration implements 
     private String licenseMappings;
 
     public static ManifestGlobalConfiguration getInstance() {
-        return GlobalConfiguration.all().getInstance(ManifestGlobalConfiguration.class);
+        return getInstance(null, null, null);
+    }
+
+    public static ManifestGlobalConfiguration getInstance(String componentMetadataOverride, String licensesOverride, String licenseMappingsOverride) {
+        var defaultConfiguration = GlobalConfiguration.all().getInstance(ManifestGlobalConfiguration.class);
+        var result = new ManifestGlobalConfiguration();
+       result.setComponentMetadata(componentMetadataOverride != null ? componentMetadataOverride : defaultConfiguration.getComponentMetadata());
+       result.setLicenses(licensesOverride != null ? licensesOverride : defaultConfiguration.getLicenses());
+       result.setLicenseMappings(licenseMappingsOverride != null ? licenseMappingsOverride : defaultConfiguration.getLicenseMappings());
+       return result;
     }
 
     public String getComponentMetadata() {

--- a/jenkins/src/main/java/de/medavis/lct/jenkins/download/LicenseDownloadBuilderFactory.java
+++ b/jenkins/src/main/java/de/medavis/lct/jenkins/download/LicenseDownloadBuilderFactory.java
@@ -33,7 +33,7 @@ import de.medavis.lct.core.metadata.ComponentMetaDataLoader;
 // TODO Try to use dependency injection (maybe using ExtensionFinder, GuiceFinder?)
 class LicenseDownloadBuilderFactory {
 
-    private static Function<Configuration, LicensesDownloader> licensesDownloaderFactory = configuration -> new LicensesDownloader(
+    private static final Function<Configuration, LicensesDownloader> defaultFactory = configuration -> new LicensesDownloader(
             new ComponentLister(
                     new AssetLoader(),
                     new ComponentMetaDataLoader(),
@@ -42,6 +42,7 @@ class LicenseDownloadBuilderFactory {
                     configuration),
             new LicenseFileDownloader()
     );
+    private static Function<Configuration, LicensesDownloader> licensesDownloaderFactory = defaultFactory;
 
     private LicenseDownloadBuilderFactory() {
     }
@@ -55,6 +56,13 @@ class LicenseDownloadBuilderFactory {
      */
     static void setLicensesDownloaderFactory(Function<Configuration, LicensesDownloader> licensesDownloaderFactory) {
         LicenseDownloadBuilderFactory.licensesDownloaderFactory = licensesDownloaderFactory;
+    }
+
+    /**
+     * Should only be used for tests
+     */
+    static void resetLicensesDownloaderFactory() {
+        LicenseDownloadBuilderFactory.licensesDownloaderFactory = defaultFactory;
     }
 
 }

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.jelly
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.jelly
@@ -12,4 +12,13 @@
     <f:entry title="${%ignoreUnavailableUrl}" field="ignoreUnavailableUrl" description="${%ignoreUnavailableUrl.description}">
         <f:checkbox />
     </f:entry>
+    <f:entry title="${%componentMetadataOverride}" field="componentMetadataOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%licensesOverride}" field="licensesOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%licenseMappingsOverride}" field="licenseMappingsOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.properties
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/create/CreateManifestBuilder/config.properties
@@ -25,3 +25,7 @@ templateUrl=Template (URL)
 templateUrl.description=URL pointing to the template for the output file. Can be file or https.
 ignoreUnavailableUrl=Ignore unavailable URL
 ignoreUnavailableUrl.description=URL of components that are not available will be ignored. Requires Internet access.
+componentMetadataOverride=Override Component meta data (URL)
+licensesOverride=Override License information (URL)
+licenseMappingsOverride=Override License name mapping (URL)
+override.description=Overrides value from global configuration for this invocation.

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/download/LicenseDownloadBuilder/config.jelly
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/download/LicenseDownloadBuilder/config.jelly
@@ -9,4 +9,13 @@
     <f:entry title="${%failOnDynamicLicense}" field="failOnDynamicLicense" description="${%failOnDynamicLicense.description}">
         <f:checkbox />
     </f:entry>
+    <f:entry title="${%componentMetadataOverride}" field="componentMetadataOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%licensesOverride}" field="licensesOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%licenseMappingsOverride}" field="licenseMappingsOverride" description="${%override.description}">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/jenkins/src/main/resources/de/medavis/lct/jenkins/download/LicenseDownloadBuilder/config.properties
+++ b/jenkins/src/main/resources/de/medavis/lct/jenkins/download/LicenseDownloadBuilder/config.properties
@@ -23,3 +23,7 @@ outputPath=Output path
 outputPath.description=Path to the output directory. Directories and files will be created and replaced as necessary.
 failOnDynamicLicense=Fail on dynamic license
 failOnDynamicLicense.description=License download will fail if at least one license is not contained in the license configuration.
+componentMetadataOverride=Override Component meta data (URL)
+licensesOverride=Override License information (URL)
+licenseMappingsOverride=Override License name mapping (URL)
+override.description=Overrides value from global configuration for this invocation.

--- a/jenkins/src/test/java/de/medavis/lct/jenkins/config/ManifestGlobalConfigurationTest.java
+++ b/jenkins/src/test/java/de/medavis/lct/jenkins/config/ManifestGlobalConfigurationTest.java
@@ -36,6 +36,7 @@ public class ManifestGlobalConfigurationTest {
     private static final String COMPONENT_METADATA_URL = "https://component.metadata.url";
     private static final String LICENSES_URL = "https://licenses.url";
     private static final String LICENSES_MAPPING_URL = "https://licenses.mapping.url";
+    private static final String OVERRIDE_URL = "https://override.url";
 
     @Rule
     public JenkinsSessionRule jenkinsSession = new JenkinsSessionRule();
@@ -51,6 +52,23 @@ public class ManifestGlobalConfigurationTest {
             verifyStoredConfig("After submit");
         });
         jenkinsSession.then(jenkins -> verifyStoredConfig("After restart"));
+    }
+
+    @Test
+    public void overrideComponentMetadata() throws Throwable {
+        jenkinsSession.then(jenkins -> {
+            // Store default values
+            HtmlForm config = jenkins.createWebClient().goTo("configure").getFormByName("config");
+            setInputValue(config, "_.componentMetadata", COMPONENT_METADATA_URL);
+            setInputValue(config, "_.licenses", LICENSES_URL);
+            setInputValue(config, "_.licenseMappings", LICENSES_MAPPING_URL);
+            jenkins.submit(config);
+
+            // Override component metadata
+            assertThat(ManifestGlobalConfiguration.getInstance(OVERRIDE_URL, null, null).getComponentMetadata()).isEqualTo(OVERRIDE_URL);
+            assertThat(ManifestGlobalConfiguration.getInstance(null, OVERRIDE_URL, null).getLicenses()).isEqualTo(OVERRIDE_URL);
+            assertThat(ManifestGlobalConfiguration.getInstance(null, null, OVERRIDE_URL).getLicenseMappings()).isEqualTo(OVERRIDE_URL);
+        });
     }
 
     private void setInputValue(HtmlForm config, String name, String value) {

--- a/jenkins/src/test/java/de/medavis/lct/jenkins/create/CreateManifestBuilderTest.java
+++ b/jenkins/src/test/java/de/medavis/lct/jenkins/create/CreateManifestBuilderTest.java
@@ -70,6 +70,9 @@ class CreateManifestBuilderTest {
             new ComponentData("name", "version", "url", Collections.emptySet(), Collections.emptySet()));
     private static final String FAKE_SBOM = "Normally, this would be a CycloneDX SBOM.";
     private static final String FAKE_MANIFEST = "IRL, I would be the manifest";
+    protected static final String COMPONENT_METADATA_OVERRIDE_URL = "http://componentMetadata.override";
+    protected static final String LICENSES_OVERRIDE_URL = "http://licenses.override";
+    protected static final String LICENSE_MAPPINGS_OVERRIDE_URL = "http://licenseMappings.override";
 
     @Mock(strictness = Strictness.LENIENT)
     private ComponentLister componentListerMock;
@@ -103,6 +106,9 @@ class CreateManifestBuilderTest {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         final CreateManifestBuilder builder = new CreateManifestBuilder(INPUT_PATH, OUTPUT_PATH);
         builder.setTemplateUrl(TEMPLATE_URL);
+        builder.setComponentMetadataOverride(COMPONENT_METADATA_OVERRIDE_URL);
+        builder.setLicensesOverride(LICENSES_OVERRIDE_URL);
+        builder.setLicenseMappingsOverride(LICENSE_MAPPINGS_OVERRIDE_URL);
         project.getBuildersList().add(builder);
         project = jenkins.configRoundtrip(project);
 
@@ -123,9 +129,9 @@ class CreateManifestBuilderTest {
     void testConfigurationOverride(JenkinsRule jenkins) throws Exception {
         runAndAssertPipelineJob(jenkins, "declarativePipelineOverride.groovy");
 
-        assertThat(capturedConfiguration.getComponentMetadataUrl()).hasValue(new URL("http://componentMetadata.override"));
-        assertThat(capturedConfiguration.getLicensesUrl()).hasValue(new URL("http://licenses.override"));
-        assertThat(capturedConfiguration.getLicenseMappingsUrl()).hasValue(new URL("http://licenseMappins.override"));
+        assertThat(capturedConfiguration.getComponentMetadataUrl()).hasValue(new URL(COMPONENT_METADATA_OVERRIDE_URL));
+        assertThat(capturedConfiguration.getLicensesUrl()).hasValue(new URL(LICENSES_OVERRIDE_URL));
+        assertThat(capturedConfiguration.getLicenseMappingsUrl()).hasValue(new URL(LICENSE_MAPPINGS_OVERRIDE_URL));
     }
 
     private void runAndAssertPipelineJob(JenkinsRule jenkins, String pipelineFile) throws Exception {

--- a/jenkins/src/test/resources/de/medavis/lct/jenkins/create/declarativePipelineOverride.groovy
+++ b/jenkins/src/test/resources/de/medavis/lct/jenkins/create/declarativePipelineOverride.groovy
@@ -1,0 +1,35 @@
+package de.medavis.lct.jenkins.create
+/*-
+ * #%L
+ * License Compliance Tool
+ * %%
+ * Copyright (C) 2022 medavis GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+pipeline {
+    agent any
+
+    stages {
+        stage('Hello') {
+            steps {
+                writeFile(file: 'input.bom', text: 'Normally, this would be a CycloneDX SBOM.')
+                componentManifest inputPath: 'input.bom', outputPath: 'output.html', templateUrl: 'file://template.ftl',
+                        componentMetadataOverride: 'http://componentMetadata.override',
+                        licensesOverride: 'http://licenses.override',
+                        licenseMappingsOverride: 'http://licenseMappins.override'
+            }
+        }
+    }
+}

--- a/jenkins/src/test/resources/de/medavis/lct/jenkins/create/declarativePipelineOverride.groovy
+++ b/jenkins/src/test/resources/de/medavis/lct/jenkins/create/declarativePipelineOverride.groovy
@@ -28,7 +28,7 @@ pipeline {
                 componentManifest inputPath: 'input.bom', outputPath: 'output.html', templateUrl: 'file://template.ftl',
                         componentMetadataOverride: 'http://componentMetadata.override',
                         licensesOverride: 'http://licenses.override',
-                        licenseMappingsOverride: 'http://licenseMappins.override'
+                        licenseMappingsOverride: 'http://licenseMappings.override'
             }
         }
     }

--- a/jenkins/src/test/resources/de/medavis/lct/jenkins/download/declarativePipelineOverride.groovy
+++ b/jenkins/src/test/resources/de/medavis/lct/jenkins/download/declarativePipelineOverride.groovy
@@ -23,8 +23,7 @@ pipeline {
     stages {
         stage('Hello') {
             steps {
-                writeFile(file: 'input.bom', text: 'Normally, this would be a CycloneDX SBOM.')
-                componentManifest inputPath: 'input.bom', outputPath: 'output.html', templateUrl: 'file://template.ftl',
+                downloadLicenses inputPath: 'input.json', outputPath: 'output/licenses',
                         componentMetadataOverride: 'http://componentMetadata.override',
                         licensesOverride: 'http://licenses.override',
                         licenseMappingsOverride: 'http://licenseMappings.override'


### PR DESCRIPTION
Different source code projects might want to use different component or license metadata. This PR introduces the option to override the global configuration during the call to the Jenkins commands `componentManifest` and `downloadLicenses`.